### PR TITLE
Obtain the path by running commands

### DIFF
--- a/run_djinni.sh
+++ b/run_djinni.sh
@@ -2,7 +2,7 @@
 set -eu
 shopt -s nullglob
 
-export DEVELOPER_DIR=/Applications/Xcode_14.1.app/Contents/Developer/
+export DEVELOPER_DIR=$(xcode-select -p)
 
 # Locate the script file.  Cross symlinks if necessary.
 loc="$0"


### PR DESCRIPTION
The xcode app does not have a version suffix by default, and the wrong path will cause compilation failure